### PR TITLE
Added Player Disconnection Logic

### DIFF
--- a/app.mjs
+++ b/app.mjs
@@ -35,7 +35,7 @@ app.get("/", (req, res) => {
 let sessions = {};
 
 io.on("connection", (socket) => {
-  var roomId = "";
+  let roomId = "";
   console.log("Connected: ", socket.id);
   socket.on("create-new-session", (callback) => {
     /**

--- a/app.mjs
+++ b/app.mjs
@@ -18,8 +18,6 @@ const io = new Server(server, {
   },
 });
 
-// var x = "";
-
 app.use(
   cors({
     origin: `http://${env.DOMAIN}:${env.CLIENT_PORT}`,
@@ -37,6 +35,7 @@ app.get("/", (req, res) => {
 let sessions = {};
 
 io.on("connection", (socket) => {
+  var roomId = "";
   console.log("Connected: ", socket.id);
   socket.on("create-new-session", (callback) => {
     /**
@@ -56,8 +55,6 @@ io.on("connection", (socket) => {
     while (sessions[generatedSessionId]) {
       generatedSessionId = randomStrGenerator();
     }
-
-    // x = generatedSessionId;
     //assigning the generated session id a game state
     sessions[generatedSessionId] = createGameState();
 
@@ -66,32 +63,43 @@ io.on("connection", (socket) => {
 
     //sending the session id to the frontend
     callback(generatedSessionId);
-
-    // if (sessions[x]?.players) console.log(sessions[x].players);
   });
 
-  // socket.on("disconnect", () => {
-  //   if (sessions[x]?.players) {
-  //     let disconnectedPlayer = sessions[x].players.findIndex((item) => {
-  //       return item.socketId === socket.id;
-  //     });
+  socket.on("disconnect", () => {
+    if (sessions[roomId]?.players) {
+      let disconnectedPlayer = sessions[roomId].players.findIndex((item) => {
+        return item.socketId === socket.id;
+      });
 
-  //     if (
-  //       sessions[x].players.length > 1 &&
-  //       sessions[x].players[disconnectedPlayer].isAdmin == true
-  //     ) {
-  //       sessions[x].players.shift();
-  //       sessions[x].players[0].isAdmin = true;
-  //       io.in(x).emit("remove-disconnected-player", sessions[x].players);
-  //     } else if (sessions[x].players.length > 1) {
-  //       sessions[x].players.splice(disconnectedPlayer, 1);
-  //       io.in(x).emit("remove-disconnected-player", sessions[x].players);
-  //     } else if (sessions[x].players.length < 1) {
-  //       delete sessions[x];
-  //     }
-  //     console.log(sessions[x].players);
-  //   }
-  // });
+      if (
+        disconnectedPlayer >= 0 &&
+        sessions[roomId].players.length > 1 &&
+        sessions[roomId].players[disconnectedPlayer].isAdmin == true
+      ) {
+        sessions[roomId].players.shift();
+        sessions[roomId].players[0].isAdmin = true;
+        io.in(roomId).emit(
+          "remove-disconnected-player",
+          sessions[roomId].players
+        );
+      } else if (
+        disconnectedPlayer >= 0 &&
+        sessions[roomId].players.length > 1
+      ) {
+        sessions[roomId].players.splice(disconnectedPlayer, 1);
+        io.in(roomId).emit(
+          "remove-disconnected-player",
+          sessions[roomId].players
+        );
+      } else if (
+        disconnectedPlayer >= 0 &&
+        sessions[roomId].players.length < 1
+      ) {
+        delete sessions[roomId];
+      }
+      console.log(sessions[roomId].players);
+    }
+  });
 
   //socket.on("join-room");
 
@@ -103,6 +111,7 @@ io.on("connection", (socket) => {
    */
   socket.on("join-session", ({ sessionId, username }, callback) => {
     let isUsernameTaken = false;
+    roomId = sessionId;
 
     onValidSessionId(
       (session) => {
@@ -133,8 +142,6 @@ io.on("connection", (socket) => {
       sessions,
       sessionId
     );
-
-    // if (sessions[x]?.players) console.log(sessions[x].players);
   });
 
   socket.on("is-admin", ({ sessionId, username }, callback) => {

--- a/app.mjs
+++ b/app.mjs
@@ -93,14 +93,12 @@ io.on("connection", (socket) => {
         );
       } else if (
         disconnectedPlayer >= 0 &&
-        sessions[roomId].players.length < 1
+        sessions[roomId].players.length <= 1
       ) {
         delete sessions[roomId];
       }
-      console.log(sessions[roomId].players);
     }
   });
-
   //socket.on("join-room");
 
   /* Connect client to session

--- a/app.mjs
+++ b/app.mjs
@@ -67,32 +67,39 @@ io.on("connection", (socket) => {
 
   socket.on("disconnect", () => {
     if (sessions[roomId]?.players) {
-      let disconnectedPlayer = sessions[roomId].players.findIndex((item) => {
-        return item.socketId === socket.id;
-      });
+      let disconnectedPlayerIndex = sessions[roomId].players.findIndex(
+        (item) => {
+          return item.socketId === socket.id;
+        }
+      );
+
+      let disconnectedPlayer =
+        sessions[roomId].players[disconnectedPlayerIndex];
 
       if (
-        disconnectedPlayer >= 0 &&
+        disconnectedPlayerIndex >= 0 &&
         sessions[roomId].players.length > 1 &&
-        sessions[roomId].players[disconnectedPlayer].isAdmin == true
+        sessions[roomId].players[disconnectedPlayerIndex].isAdmin == true
       ) {
         sessions[roomId].players.shift();
         sessions[roomId].players[0].isAdmin = true;
         io.in(roomId).emit(
           "remove-disconnected-player",
-          sessions[roomId].players
+          sessions[roomId].players,
+          disconnectedPlayer
         );
       } else if (
-        disconnectedPlayer >= 0 &&
+        disconnectedPlayerIndex >= 0 &&
         sessions[roomId].players.length > 1
       ) {
-        sessions[roomId].players.splice(disconnectedPlayer, 1);
+        sessions[roomId].players.splice(disconnectedPlayerIndex, 1);
         io.in(roomId).emit(
           "remove-disconnected-player",
-          sessions[roomId].players
+          sessions[roomId].players,
+          disconnectedPlayer
         );
       } else if (
-        disconnectedPlayer >= 0 &&
+        disconnectedPlayerIndex >= 0 &&
         sessions[roomId].players.length <= 1
       ) {
         delete sessions[roomId];


### PR DESCRIPTION
Whenever a player closes the windows, the disconnect event is called in the backend and that player will be removed from the sessions object and will be broadcasted to every remaining player in the room and modifies the local storage and states of every player. Also if the Admin leaves the lobby, admin privileges will be given to the player next to the admin.